### PR TITLE
Fixing error "Calling Formula.sha1 is disabled!"

### DIFF
--- a/sphinx.rb
+++ b/sphinx.rb
@@ -1,15 +1,15 @@
 require 'formula'
 
 class Sphinx < Formula
-  url 'https://s3-eu-west-1.amazonaws.com/rnaveiras-software/sphinx-0.9.9.tar.gz'
+  url 'http://sphinxsearch.com/files/archive/sphinx-0.9.9.tar.gz'
   homepage 'http://www.sphinxsearch.com'
-  sha1 '8c739b96d756a50972c27c7004488b55d7458015'
+  sha256 'bf8f55ffc095ff6b628f0cbc7eb54761811140140679a1c869cc1b17c42803e4'
 
   depends_on 'homebrew/dupes/apple-gcc42'
 
   resource 'stemmer' do
     url 'https://s3-eu-west-1.amazonaws.com/rnaveiras-software/libstemmer_c.tgz'
-    sha1 '6645992e5a5023dfd7eecf99fbcc58ec8b41facf'
+    sha1 'b80ed040f0f42945ea056cc7dc37fc493afd278ff4215c42d67fbbc7f8bde172'
     # homepage 'http://snowball.tartarus.org/'
   end
 

--- a/sphinx.rb
+++ b/sphinx.rb
@@ -9,7 +9,7 @@ class Sphinx < Formula
 
   resource 'stemmer' do
     url 'https://s3-eu-west-1.amazonaws.com/rnaveiras-software/libstemmer_c.tgz'
-    sha1 'b80ed040f0f42945ea056cc7dc37fc493afd278ff4215c42d67fbbc7f8bde172'
+    sha256 'b80ed040f0f42945ea056cc7dc37fc493afd278ff4215c42d67fbbc7f8bde172'
     # homepage 'http://snowball.tartarus.org/'
   end
 


### PR DESCRIPTION
```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/rnaveiras/homebrew-sphinx/sphinx.rb
Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
```